### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/hxlnt/83c1a95a-4a0b-4bf3-97c6-0f933a7e3d0c/4fbe6ea5-2806-49dc-a76a-0d01f66fef3b/_apis/work/boardbadge/d6d15575-f1fa-4121-b011-eac03fa4dbe1)](https://dev.azure.com/hxlnt/83c1a95a-4a0b-4bf3-97c6-0f933a7e3d0c/_boards/board/t/4fbe6ea5-2806-49dc-a76a-0d01f66fef3b/Microsoft.RequirementCategory)
 # w2


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hxlnt/83c1a95a-4a0b-4bf3-97c6-0f933a7e3d0c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.